### PR TITLE
Fix mapFunction assertion and cover builder filter path

### DIFF
--- a/dmask-core/src/main/java/com/butreik/dmask/core/JsonMaskImpl.java
+++ b/dmask-core/src/main/java/com/butreik/dmask/core/JsonMaskImpl.java
@@ -255,7 +255,7 @@ public class JsonMaskImpl implements JsonMask {
              * @return the builder instance
              */
             private FiltersBuilder masker(MapFunction mapFunction) {
-                assertNotNull(masker);
+                assertNotNull(mapFunction);
                 this.masker = Masker.builder().mapFunction(mapFunction).build();
                 return this;
             }

--- a/dmask-core/src/test/java/com/butreik/dmask/core/JsonMaskBuilderTest.java
+++ b/dmask-core/src/test/java/com/butreik/dmask/core/JsonMaskBuilderTest.java
@@ -1,0 +1,21 @@
+package com.butreik.dmask.core;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+public class JsonMaskBuilderTest {
+
+    @Test
+    public void filterMapFunctionBuilderTest() throws JSONException {
+        JsonMask jsonMask = JsonMaskImpl.builder()
+                .filter(input -> "MASKED", fb -> fb.jsonPath("$.value1").jsonPath("$.value2"))
+                .build();
+
+        String inputJson = "{ \"value1\":\"one\", \"value2\":\"two\", \"value3\":\"three\" }";
+        String expectedJson = "{ \"value1\":\"MASKED\", \"value2\":\"MASKED\", \"value3\":\"three\" }";
+
+        assertEquals(expectedJson, jsonMask.mask(inputJson), true);
+    }
+}


### PR DESCRIPTION
## Summary
- validate `mapFunction` in `FiltersBuilder` to avoid erroneous null checks
- add regression test for applying a `MapFunction` via `FiltersBuilder`

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.junit:junit-bom:pom:5.9.2, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689efcd4473c83329656927a3d0de7b6